### PR TITLE
Migrate logger to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # mankeli_core changelog
 
+## 0.0.6
+
+- Removes DCM dependencies
+- Migrates logger dependency to 2.x
+- Updates dependencies
+
 ## 0.0.5
 
 - Makes case modifying support all capslock input

--- a/lib/src/app_logger.dart
+++ b/lib/src/app_logger.dart
@@ -43,7 +43,7 @@ class AppLogger {
   /// Use [AppLogger.instance.verbose] or [AppLogger.v] to log and
   /// override verbose logs
   /// {@endtemplate}
-  LoggerCallback verbose = defaultLogger.v;
+  LoggerCallback verbose = _log(defaultLogger.t);
 
   /// {@template debug}
   /// {@macro logger}
@@ -51,7 +51,7 @@ class AppLogger {
   /// Use [AppLogger.instance.debug] or [AppLogger.d] to log and
   /// override debug logs
   /// {@endtemplate}
-  LoggerCallback debug = defaultLogger.d;
+  LoggerCallback debug = _log(defaultLogger.d);
 
   /// {@template info}
   /// {@macro logger}
@@ -59,7 +59,7 @@ class AppLogger {
   /// Use [AppLogger.instance.info] or [AppLogger.i] to log and
   /// override info logs
   /// {@endtemplate}
-  LoggerCallback info = defaultLogger.i;
+  LoggerCallback info = _log(defaultLogger.i);
 
   /// {@template warning}
   /// {@macro logger}
@@ -67,7 +67,7 @@ class AppLogger {
   /// Use [AppLogger.instance.warning] or [AppLogger.w] to log and
   /// override warning logs
   /// {@endtemplate}
-  LoggerCallback warning = defaultLogger.w;
+  LoggerCallback warning = _log(defaultLogger.w);
 
   /// {@template error}
   /// {@macro logger}
@@ -75,7 +75,7 @@ class AppLogger {
   /// Use [AppLogger.instance.error] or [AppLogger.e] to log and
   /// override error logs
   /// {@endtemplate}
-  LoggerCallback error = defaultLogger.e;
+  LoggerCallback error = _log(defaultLogger.e);
 
   /// {@template wtf}
   /// {@macro logger}
@@ -83,7 +83,7 @@ class AppLogger {
   /// Use [AppLogger.instance.whatTheFuck] or [AppLogger.wtf] to log and
   /// override wtf logs
   /// {@endtemplate}
-  LoggerCallback whatTheFuck = defaultLogger.wtf;
+  LoggerCallback whatTheFuck = _log(defaultLogger.f);
 
   /// {@template analytic}
   /// {@macro logger}
@@ -124,4 +124,22 @@ class AppLogger {
 
   /// {@macro crashlytic}
   static LoggerCallback get c => instance.crashlytic;
+
+  static LoggerCallback _log(
+    FutureOr<void> Function(
+      dynamic message, {
+      DateTime? time,
+      Object? error,
+      StackTrace? stackTrace,
+    }) callback,
+  ) {
+    FutureOr<void> log(
+      String message, [
+      dynamic error,
+      StackTrace? stackTrace,
+    ]) =>
+        callback(message, error: error, stackTrace: stackTrace);
+
+    return log;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mankeli_core
 description: A Core Package Which Contains Miscaellaneous Stuff Used Across All
   Of Mankeli Solutions Dart Projects
-version: 0.0.5
+version: 0.0.6
 homepage: https://mankeli.co
 repository: https://github.com/Mankeli-Software/mankeli_core
 issue_tracker: https://github.com/Mankeli-Software/mankeli_core/issues
@@ -10,11 +10,8 @@ environment:
   sdk: '>=3.0.5 <4.0.0'
 
 dependencies:
-  logger: ^1.3.0
-  meta: ^1.8.0
-
+  logger: ^2.4.0
+  meta: ^1.16.0
 
 dev_dependencies:
-  dart_code_metrics: any
-  mankeli_analysis: ^1.1.0
-
+  mankeli_analysis: ^1.1.2


### PR DESCRIPTION
## Description

Fixes #1 

1) Migrated `logger` to [2.x](https://github.com/SourceHorizon/logger/blob/main/CHANGELOG.md#200)
2) Removed dependency on dart code metrics
3) Updated all other deps to their latest versions

---

Ideally, `LoggerCallback`'s signature should be changed to match the new signature of `logger`'s callback, but that would introduce a breaking change. I make an adapter function that converts the new callback's signature to the old one (which is used by `LoggerCallback`). The makes my changes **non-breaking**

If you decide that changing the `LoggerCallback`'s signature (and thus introducing a breaking change) is preferred, let me know - I will update my PR.

---

In addition, `verbose` was renamed to `trace`; and `wtf` was renamed to `fatal`. I kept the original function names.

## Conventional Type

<!--- Put an 'x' into the conventional commit boxes that match the PR -->

- [ ] ✨ feat
- [ ] 🛠️ fix
- [x] ✅ chore
- [ ] 📝 doc
- [ ] 🧪 test
- [ ] ❌ BREAKING CHANGE
